### PR TITLE
Fix nested attributes for has_one 

### DIFF
--- a/lib/active_record/mass_assignment_security/nested_attributes.rb
+++ b/lib/active_record/mass_assignment_security/nested_attributes.rb
@@ -50,6 +50,12 @@ module ActiveRecord
 
       def assign_nested_attributes_for_one_to_one_association(association_name, attributes, assignment_opts = {})
         options = self.nested_attributes_options[association_name]
+        if attributes.class.name == 'ActionController::Parameters'
+          attributes = attributes.to_unsafe_h
+        elsif !attributes.is_a?(Hash) && !attributes.is_a?(Array)
+          raise ArgumentError, "ActionController::Parameters or Hash or Array expected, got #{attributes.class.name} (#{attributes.inspect})"
+        end
+
         attributes = attributes.with_indifferent_access
 
         if  (options[:update_only] || !attributes['id'].blank?) && (record = send(association_name)) &&


### PR DESCRIPTION
with_indifferent_access is no longer present on ActionController::Parameters in Rails 5.1

So convert to hash first, as per assign_nested_attributes_for_collection_association

Fixes #6 