### PR TITLE
Fix `inheritance_column` attr isn't protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add Rails 5.2 support
 * Fix bug related to incorrect usage of options on the AR#new method
 * Use scope_for_create instead of create_scope in Rails 5.2+
+* Fix bug related to protection of `inheritance_column` attribute
 
 ## 1.3.0
 

--- a/lib/active_record/mass_assignment_security/inheritance.rb
+++ b/lib/active_record/mass_assignment_security/inheritance.rb
@@ -9,14 +9,7 @@ module ActiveRecord
 
         # Detect the subclass from the inheritance column of attrs. If the inheritance column value
         # is not self or a valid subclass, raises ActiveRecord::SubclassNotFound
-        # If this is a StrongParameters hash, and access to inheritance_column is not permitted,
-        # this will ignore the inheritance column and return nil
-        def subclass_from_attributes?(attrs)
-          active_authorizer[:default].deny?(inheritance_column) ? nil : super
-        end
-
-        # Support Active Record <= 4.0.3, which uses the old method signature.
-        def subclass_from_attrs(attrs)
+        def subclass_from_attributes(attrs)
           active_authorizer[:default].deny?(inheritance_column) ? nil : super
         end
       end

--- a/test/attribute_sanitization_test.rb
+++ b/test/attribute_sanitization_test.rb
@@ -270,9 +270,7 @@ class AttributeSanitizationTest < ActiveSupport::TestCase
   def test_new_with_protected_inheritance_column
     firm = Company.new(type: "Firm")
 
-    ### TEST IS FAILING, SO I MADE IT PASS
-    #assert_equal Company, firm.class #original line
-    assert_equal Firm, firm.class
+    assert_equal Company, firm.class
   end
 
   def test_new_with_accessible_inheritance_column


### PR DESCRIPTION
During upgrade Rails from 4.2 to 5.0 I'd got a test failure that
show that `inheritance_column` attr isn't protected anymore.

After debugging I found that we have overridden `subclass_from_attributes?` to protect that column.
Since Rails 5.0 that method is removed from Rails codebase
that causess that issue, see https://github.com/rails/rails/commit/3da890f891b116218c10d9b049dba23d15d416cf

In order to fix this bug we should override `subclass_from_attributes`
instead.

Overriding of `subclass_from_attributes?`, and `subclass_from_attrs`
should be removed since `protected_attributes_continued` dropped support of Rails < 5,
see https://github.com/Current-RMS/protected_attributes_continued/blob/master/CHANGELOG.md#130

Since it is security fix I think we should release 1.3.1 with that fix
too.