### PR TITLE
Fix for nested assignment not processed properly 

### DIFF
--- a/lib/active_record/mass_assignment_security/attribute_assignment.rb
+++ b/lib/active_record/mass_assignment_security/attribute_assignment.rb
@@ -61,7 +61,7 @@ module ActiveRecord
         attributes.each do |k, v|
           if k.include?("(")
             multi_parameter_attributes << [ k, v ]
-          elsif v.is_a?(Hash)
+          elsif v.is_a?(Hash) || v.is_a?(ActionController::Parameters)
             nested_parameter_attributes << [ k, v ]
           else
             _assign_attribute(k, v)


### PR DESCRIPTION
Triggers in case of strong_params. It causes issues when you have dependent fields on one another.
