### PR TITLE
Handle passing in named attributes as parameters to ApplicationRecord#new in rails 5.0

### DIFF
--- a/lib/active_record/mass_assignment_security/inheritance.rb
+++ b/lib/active_record/mass_assignment_security/inheritance.rb
@@ -22,10 +22,12 @@ module ActiveRecord
     module ClassMethods
       undef :new
 
-      def new(attributes = nil, options = {}, &block)
+      def new(*args, &block)
         if abstract_class? || self == Base
           raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
         end
+
+        attributes = args.first
 
         if has_attribute?(inheritance_column)
           subclass = subclass_from_attributes(attributes)
@@ -36,7 +38,7 @@ module ActiveRecord
         end
 
         if subclass && subclass != self
-          subclass.new(attributes, options, &block)
+          subclass.new(*args, &block)
         else
           super
         end


### PR DESCRIPTION
Handle passing in named attributes as parameters to ApplicationRecord#new in rails 5.0

Prior to this patch, the following code would fail:
```ruby
class SomeModel < ApplicationRecord
  def initialize(options = {})
    @foo = options[:foo]
    self.foo = @foo
  end
end

SomeModel.new(some_attribute: 'foo')
```

The error would come in as 

```
ArgumentError:
       wrong number of arguments (given 2, expected 0..1)
     # ./app/models/some_model.rb:2:in `initialize'
```

Upon further inspection, it appeared that two hashes were being sent into the call to #new from the monkey patch in ClassMethods#new. The separation between attributes and options was not being handled.

This patch introduces code from https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/inheritance.rb which properly handles the passing-in of named parameters.

Tested as passing via appraisal.