### PR TITLE
Possible fix for new records in Rails 6

### DIFF
--- a/lib/active_record/mass_assignment_security/core.rb
+++ b/lib/active_record/mass_assignment_security/core.rb
@@ -3,6 +3,7 @@ module ActiveRecord
     module Core
 
       def initialize(attributes = nil, options = {})
+        @new_record = true
         self.class.define_attribute_methods
         @attributes = self.class._default_attributes.deep_dup
 


### PR DESCRIPTION
Related to https://github.com/westonganger/protected_attributes_continued/issues/15, I was having issues with any new records that were supposed to be created issuing `UPDATE` sql calls instead of `INSERT`. They would come back thinking they were persisted, but they didn't have an `id` attribute because of the invalid sql call made.

I looked through forks of this project and found one with a one line commit that fixed the immediate issue I was having, though I'll be testing this out more as I prep a Rails 6 release for a legacy project.

The code was originally found at https://github.com/zarmin/protected_attributes_continued/commit/532b731b6306abca2c23d86cb674b15dbc30ab50