### PR TITLE
Preserve scoping when building associations with conditions

### DIFF
--- a/lib/active_record/mass_assignment_security/association_relation.rb
+++ b/lib/active_record/mass_assignment_security/association_relation.rb
@@ -5,29 +5,41 @@ module ActiveRecord
     undef :create!
 
     def build(attributes = nil, options = {}, &block)
-      if ActiveRecord::VERSION::STRING.to_f < 5.2
-        scoping { @association.build(attributes, options, &block) }
-      else
-        @association.build(attributes, options, &block)
-      end
+      block = protected_attributes_scope_block('new', block)
+      scoping { @association.build(attributes, options, &block) }
     end
     alias new build
 
     def create(attributes = nil, options = {}, &block)
-      if ActiveRecord::VERSION::STRING.to_f < 5.2
-        scoping { @association.create(attributes, options, &block) }
-      else
-        @association.create(attributes, options, &block)
-      end
+      block = protected_attributes_scope_block('create', block)
+      scoping { @association.create(attributes, options, &block) }
     end
 
     def create!(attributes = nil, options = {}, &block)
-      if ActiveRecord::VERSION::STRING.to_f < 5.2
-        scoping { @association.create!(attributes, options, &block) }
-      else
-        @association.create!(attributes, options, &block)
-      end
+      block = protected_attributes_scope_block('create!', block)
+      scoping { @association.create!(attributes, options, &block) }
     end
 
+    private
+
+    if ActiveRecord.gem_version < Gem::Version.new('6.0')
+
+      def protected_attributes_scope_block(_label, block)
+        block
+      end
+
+    elsif ActiveRecord.gem_version < Gem::Version.new('6.1')
+
+      def protected_attributes_scope_block(label, block)
+        _deprecated_scope_block(label, &block)
+      end
+
+    else
+
+      def protected_attributes_scope_block(_label, block)
+        current_scope_restoring_block(&block)
+      end
+
+    end
   end
 end

--- a/test/mass_assignment_security/association_relation_test.rb
+++ b/test/mass_assignment_security/association_relation_test.rb
@@ -10,4 +10,22 @@ class AssociationRelationTest < ActiveSupport::TestCase
     group = Group.create
     assert_nothing_raised { group.memberships.where("1=1").first_or_create }
   end
+
+  test "build passes scoped attributes" do
+    group = Group.create
+    membership = group.memberships.where(pirate_id: 1).build
+    assert_equal(1, membership.pirate_id)
+  end
+
+  test "create passes scoped attributes" do
+    group = Group.create
+    membership = group.memberships.where(pirate_id: 1).create
+    assert_equal(1, membership.pirate_id)
+  end
+
+  test "create! passes scoped attributes" do
+    group = Group.create
+    membership = group.memberships.where(pirate_id: 1).create!
+    assert_equal(1, membership.pirate_id)
+  end
 end


### PR DESCRIPTION
With 1.8.0, #21 introduced a change that no longer preserves values from the scope chain on associations:

```
membership = group.memberships.where(pirate_id: 1).build
membership.pirate_id  # expected: 1, got nil
```

