### PR TITLE
fix(associations): don't call object_id on record

### DIFF
--- a/lib/active_record/mass_assignment_security/associations.rb
+++ b/lib/active_record/mass_assignment_security/associations.rb
@@ -92,7 +92,23 @@ module ActiveRecord
     end
 
     class HasManyThroughAssociation
-      if ActiveRecord.version >= Gem::Version.new('5.2.3')
+      if ActiveRecord.version >= Gem::Version.new('6.1')
+        undef :build_through_record
+        def build_through_record(record)
+          @through_records[record] ||= begin
+            ensure_mutable
+
+            attributes = through_scope_attributes
+            attributes[source_reflection.name] = record
+            attributes[source_reflection.foreign_type] = options[:source_type] if options[:source_type]
+
+            # Pass in `without_protection: true` here because `options_for_through_record`
+            # was removed in https://github.com/rails/rails/pull/35799
+            through_association.build(attributes, without_protection: true)
+          end
+        end
+        private :build_through_record
+      elsif ActiveRecord.version >= Gem::Version.new('5.2.3')
         undef :build_through_record
         def build_through_record(record)
           @through_records[record.object_id] ||= begin


### PR DESCRIPTION
In Rails 6.1, the `@through_records` Hash is indexed using the `record` itself. The call to `object_id` was removed by this commit https://github.com/rails/rails/commit/42914820d91ded5b1fb285448bbde8620e00f33c

This gem's override of the method was putting the new `through_records` in the wrong place and making it so that they would not be saved when the root record was a new record.

I added a new override for AR versions >= 6.1 that matches the implementation in 6.1.