### PR TITLE
fix(associations): redefine build_record for CollectionAssociation

### DIFF
--- a/lib/active_record/mass_assignment_security/associations.rb
+++ b/lib/active_record/mass_assignment_security/associations.rb
@@ -55,6 +55,18 @@ module ActiveRecord
         end
       end
       private :create_record
+
+      if ActiveRecord.version >= Gem::Version.new("6.0.4") && ActiveRecord.version < Gem::Version.new("6.1")
+        undef :build_record
+
+        def build_record(attributes, options)
+          previous = klass.current_scope(true) if block_given?
+          super
+        ensure
+          klass.current_scope = previous if previous
+        end
+        private :build_record
+      end
     end
 
     class CollectionProxy


### PR DESCRIPTION
In Rails 6.0.4, CollectionAssociation defines its own implementation of build_record which overrides the one inherited from the Association base class. This breaks protected_attributes_continued's redefinition because now CollectionAssociation is no longer using the implementation from the super class.

I fixed this by checking if CollectionAssociation defines its own build_record by using private_instance_methods(false). If it does, I undef'd it, and then added a new implementation that accepts the extra options argument. The implementation is just the same as the one from main.

See this commit for the addition of build_record to CollectionAssociation: https://github.com/rails/rails/commit/11928670bdcca61ae128da306d39291d0556e942

Only appears in the 6-0-stable branch, first released in the v6.0.4 tag.

Does not appear in the 6-1-stable or main branches. I assume the issue this was fixing is not present in those branches, but I'm not sure. However, in 6.1.x, `private_instance_methods(false).include?(:build_record)` returns false, so I think the conditional I used to target this patch should only hit 6.0.4.